### PR TITLE
add vote instructions and interface

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,6 +7,8 @@ pub mod error;
 pub mod instruction;
 pub mod processor;
 pub mod state;
+pub mod vote;
+mod vote_processor;
 
 // Export current SDK types for downstream users building with a different SDK
 // version

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -3,6 +3,8 @@
 use bytemuck::{Pod, Zeroable};
 use solana_program::account_info::AccountInfo;
 use solana_program::clock::Clock;
+use solana_program::clock::Slot;
+use solana_program::hash::Hash;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use spl_pod::primitives::{PodI64, PodU64};
@@ -11,8 +13,8 @@ use crate::accounting::{AuthorizedVoter, EpochCredit};
 use crate::instruction::InitializeAccountInstructionData;
 
 pub(crate) type PodEpoch = PodU64;
-type PodSlot = PodU64;
-type PodUnixTimestamp = PodI64;
+pub(crate) type PodSlot = PodU64;
+pub(crate) type PodUnixTimestamp = PodI64;
 
 /// The accounting and vote information associated with
 /// this vote account
@@ -20,29 +22,53 @@ type PodUnixTimestamp = PodI64;
 #[derive(Clone, Copy, Debug, Pod, Zeroable, Default, PartialEq)]
 pub struct VoteState {
     /// The current vote state version
-    pub version: u8,
+    pub(crate) version: u8,
 
     /// The node that votes in this account
-    pub node_pubkey: Pubkey,
+    pub(crate) node_pubkey: Pubkey,
 
     /// The signer for withdrawals
-    pub authorized_withdrawer: Pubkey,
+    pub(crate) authorized_withdrawer: Pubkey,
 
     /// Percentage (0-100) that represents what part of a rewards
     /// payout should be given to this VoteAccount
-    pub commission: u8,
+    pub(crate) commission: u8,
 
     /// The signer for vote transactions in this epoch
-    pub authorized_voter: AuthorizedVoter,
+    pub(crate) authorized_voter: AuthorizedVoter,
 
     /// The signer for vote transaction in an upcoming epoch
-    pub next_authorized_voter: Option<AuthorizedVoter>,
+    pub(crate) next_authorized_voter: Option<AuthorizedVoter>,
 
     /// How many credits this validator is earning in this Epoch
-    pub epoch_credits: EpochCredit,
+    pub(crate) epoch_credits: EpochCredit,
 
     /// Most recent timestamp submitted with a vote
-    pub last_timestamp: BlockTimestamp,
+    pub(crate) latest_timestamp: BlockTimestamp,
+
+    /// The latest notarized slot
+    pub(crate) latest_notarized_slot: PodSlot,
+
+    /// The latest notarized block_id
+    pub(crate) latest_notarized_block_id: Hash,
+
+    /// The latest finalized slot
+    pub(crate) latest_finalized_slot: PodSlot,
+
+    /// The latest finalized block_id
+    pub(crate) latest_finalized_block_id: Hash,
+
+    /// The latest skip range start slot
+    pub(crate) latest_skip_start_slot: PodSlot,
+
+    /// The latest skip range end slot
+    pub(crate) latest_skip_end_slot: PodSlot,
+
+    /// The slot of the latest replayed block
+    pub(crate) replayed_slot: PodSlot,
+
+    /// The bank hash of the latest replayed block
+    pub(crate) replayed_bank_hash: Hash,
 }
 
 /// Represents the time at which a block was voted on
@@ -94,5 +120,161 @@ impl VoteState {
     /// The size of the vote account that stores this VoteState
     pub const fn size() -> usize {
         std::mem::size_of::<VoteState>()
+    }
+
+    /// Vote state version
+    pub fn version(&self) -> u8 {
+        self.version
+    }
+
+    /// Validator that votes in this account
+    pub fn node_pubkey(&self) -> &Pubkey {
+        &self.node_pubkey
+    }
+
+    /// Signer for withdrawals
+    pub fn authorized_withdrawer(&self) -> &Pubkey {
+        &self.authorized_withdrawer
+    }
+
+    /// Percentage (0-100) that represents what part of a rewards
+    /// payout should be given to this VoteAccount
+    pub fn commission(&self) -> u8 {
+        self.commission
+    }
+
+    /// The signer for vote transactions in this epoch
+    pub fn authorized_voter(&self) -> &AuthorizedVoter {
+        &self.authorized_voter
+    }
+
+    /// The signer for vote transactions in an upcoming epoch
+    pub fn next_authorized_voter(&self) -> Option<&AuthorizedVoter> {
+        self.next_authorized_voter.as_ref()
+    }
+
+    /// How many credits this validator is earning in this Epoch
+    pub fn epoch_credits(&self) -> &EpochCredit {
+        &self.epoch_credits
+    }
+
+    /// Most recent timestamp submitted with a vote
+    pub fn latest_timestamp(&self) -> &BlockTimestamp {
+        &self.latest_timestamp
+    }
+
+    /// The latest notarized slot
+    pub fn latest_notarized_slot(&self) -> Slot {
+        Slot::from(self.latest_notarized_slot)
+    }
+
+    /// The latest notarized block_id
+    pub fn latest_notarized_block_id(&self) -> &Hash {
+        &self.latest_notarized_block_id
+    }
+
+    /// The latest finalized slot
+    pub fn latest_finalized_slot(&self) -> Slot {
+        Slot::from(self.latest_finalized_slot)
+    }
+
+    /// The latest finalized block_id
+    pub fn latest_finalized_block_id(&self) -> &Hash {
+        &self.latest_finalized_block_id
+    }
+
+    /// The latest skip range start slot
+    pub fn latest_skip_start_slot(&self) -> Slot {
+        Slot::from(self.latest_skip_start_slot)
+    }
+
+    /// The latest skip range end slot
+    pub fn latest_skip_end_slot(&self) -> Slot {
+        Slot::from(self.latest_skip_end_slot)
+    }
+
+    /// The slot of the latest replayed block
+    pub fn replayed_slot(&self) -> Slot {
+        Slot::from(self.replayed_slot)
+    }
+
+    /// The bank hash of the latest replayed block
+    pub fn replayed_bank_hash(&self) -> &Hash {
+        &self.replayed_bank_hash
+    }
+
+    /// Set the node_pubkey
+    pub fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
+        self.node_pubkey = node_pubkey
+    }
+
+    /// Set the authorized withdrawer
+    pub fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
+        self.authorized_withdrawer = authorized_withdrawer
+    }
+
+    /// Set the commission
+    pub fn set_commission(&mut self, commission: u8) {
+        self.commission = commission
+    }
+
+    /// Set the authorized voter
+    pub fn set_authorized_voter(&mut self, authorized_voter: AuthorizedVoter) {
+        self.authorized_voter = authorized_voter
+    }
+
+    /// Set the next authorized voter
+    pub fn set_next_authorized_voter(&mut self, next_authorized_voter: AuthorizedVoter) {
+        self.next_authorized_voter = Some(next_authorized_voter)
+    }
+
+    /// Set the epoch credits
+    pub fn set_epoch_credits(&mut self, epoch_credits: EpochCredit) {
+        self.epoch_credits = epoch_credits
+    }
+
+    /// Set the latest timestamp
+    pub fn set_latest_timestamp(&mut self, latest_timestamp: BlockTimestamp) {
+        self.latest_timestamp = latest_timestamp
+    }
+
+    /// Set the latest notarized slot
+    pub fn set_latest_notarized_slot(&mut self, latest_notarized_slot: Slot) {
+        self.latest_notarized_slot = PodSlot::from(latest_notarized_slot)
+    }
+
+    /// Set the latest notarized block id
+    pub fn set_latest_notarized_block_id(&mut self, latest_notarized_block_id: Hash) {
+        self.latest_notarized_block_id = latest_notarized_block_id
+    }
+
+    /// Set the latest finalized slot
+    pub fn set_latest_finalized_slot(&mut self, latest_finalized_slot: Slot) {
+        self.latest_finalized_slot = PodSlot::from(latest_finalized_slot)
+    }
+
+    /// Set the latest finalized block id
+    pub fn set_latest_finalized_block_id(&mut self, latest_finalized_block_id: Hash) {
+        self.latest_finalized_block_id = latest_finalized_block_id
+    }
+
+    /// Set the latest skip start slot
+    pub fn set_latest_skip_start_slot(&mut self, latest_skip_start_slot: Slot) {
+        self.latest_skip_start_slot = PodSlot::from(latest_skip_start_slot)
+    }
+
+    /// Set the latest skip end slot
+    pub fn set_latest_skip_end_slot(&mut self, latest_skip_end_slot: Slot) {
+        self.latest_skip_end_slot = PodSlot::from(latest_skip_end_slot)
+    }
+
+    /// Set the latest replayed slot
+    pub fn set_replayed_slot(&mut self, replayed_slot: Slot) {
+        self.replayed_slot = PodSlot::from(replayed_slot)
+    }
+
+    /// Set the latest replayed bank hash
+    pub fn set_replayed_bank_hash(&mut self, replayed_bank_hash: Hash) {
+        self.replayed_bank_hash = replayed_bank_hash
     }
 }

--- a/program/src/vote.rs
+++ b/program/src/vote.rs
@@ -1,0 +1,269 @@
+//! Vote data types for use by clients
+
+use solana_program::clock::{Slot, UnixTimestamp};
+use solana_program::hash::Hash;
+use solana_program::program_error::ProgramError;
+
+use crate::instruction::{decode_instruction_data, decode_instruction_type, VoteInstruction};
+use crate::vote_processor::{
+    FinalizationVoteInstructionData, NotarizationVoteInstructionData, SkipVoteInstructionData,
+};
+
+/// Enum that clients can use to parse and create the vote
+/// structures expected by the program
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Vote {
+    /// A notarization vote
+    NotarizationVote(NotarizationVote),
+    /// A finalization vote
+    FinalizationVote(FinalizationVote),
+    /// A skip vote
+    SkipVote(SkipVote),
+}
+
+macro_rules! dispatch {
+    (
+        $(#[$($attrss:tt)*])*
+        $vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?
+    ) => {
+        $(#[$($attrss)*])*
+        #[inline]
+        $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
+            match self {
+                Self::NotarizationVote(shred) => shred.$name($($arg, )?),
+                Self::FinalizationVote(shred) => shred.$name($($arg, )?),
+                Self::SkipVote(shred) => shred.$name($($arg, )?),
+            }
+        }
+    };
+}
+
+impl Vote {
+    dispatch! {
+        /// The time at which this vote was created
+        pub fn timestamp(&self) -> UnixTimestamp
+    }
+
+    /// If this instruction represented by `instruction_data` is a vote
+    pub fn is_simple_vote(instruction_data: &[u8]) -> Result<bool, ProgramError> {
+        let instruction_type = decode_instruction_type(instruction_data)?;
+        Ok(matches!(
+            instruction_type,
+            VoteInstruction::Notarize | VoteInstruction::Finalize | VoteInstruction::Skip
+        ))
+    }
+
+    /// Deserializes instruction represented by `instruction_data` into a `Vote`
+    /// Must be guarded by `is_simple_vote`
+    pub fn deserialize_simple_vote(instruction_data: &[u8]) -> Result<Vote, ProgramError> {
+        debug_assert!(Self::is_simple_vote(instruction_data)?);
+        let instruction_type = decode_instruction_type(instruction_data)?;
+        match instruction_type {
+            VoteInstruction::Notarize => {
+                let notarization_vote =
+                    decode_instruction_data::<NotarizationVoteInstructionData>(instruction_data)?;
+                Ok(Vote::from(NotarizationVote::new_internal(
+                    notarization_vote,
+                )))
+            }
+            VoteInstruction::Finalize => {
+                let finalization_vote =
+                    decode_instruction_data::<FinalizationVoteInstructionData>(instruction_data)?;
+                Ok(Vote::from(FinalizationVote::new_internal(
+                    finalization_vote,
+                )))
+            }
+            VoteInstruction::Skip => {
+                let skip_vote =
+                    decode_instruction_data::<SkipVoteInstructionData>(instruction_data)?;
+                Ok(Vote::from(SkipVote::new_internal(skip_vote)))
+            }
+            _ => panic!("Programmer error"),
+        }
+    }
+}
+
+impl From<NotarizationVote> for Vote {
+    fn from(vote: NotarizationVote) -> Self {
+        Self::NotarizationVote(vote)
+    }
+}
+
+impl From<FinalizationVote> for Vote {
+    fn from(vote: FinalizationVote) -> Self {
+        Self::FinalizationVote(vote)
+    }
+}
+
+impl From<SkipVote> for Vote {
+    fn from(vote: SkipVote) -> Self {
+        Self::SkipVote(vote)
+    }
+}
+
+/// A notarization vote
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NotarizationVote {
+    slot: Slot,
+    block_id: Hash,
+    replayed_slot: Slot,
+    replayed_bank_hash: Hash,
+    timestamp: UnixTimestamp,
+}
+
+impl NotarizationVote {
+    fn new_internal(notarization_vote: &NotarizationVoteInstructionData) -> Self {
+        Self {
+            slot: Slot::from(notarization_vote.slot),
+            block_id: notarization_vote.block_id,
+            replayed_slot: Slot::from(notarization_vote.replayed_slot),
+            replayed_bank_hash: notarization_vote.replayed_bank_hash,
+            timestamp: UnixTimestamp::from(notarization_vote.timestamp),
+        }
+    }
+
+    /// Construct a notarization vote for `slot`
+    pub fn new(
+        slot: Slot,
+        block_id: Hash,
+        replayed_slot: Slot,
+        replayed_bank_hash: Hash,
+        timestamp: UnixTimestamp,
+    ) -> Self {
+        Self {
+            slot,
+            block_id,
+            replayed_slot,
+            replayed_bank_hash,
+            timestamp,
+        }
+    }
+
+    /// The slot to notarize
+    pub fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    /// The block_id of the notarization slot
+    pub fn block_id(&self) -> &Hash {
+        &self.block_id
+    }
+
+    /// The latest replayed slot
+    pub fn replayed_slot(&self) -> Slot {
+        self.replayed_slot
+    }
+
+    /// The bank hash of the latest replayed slot
+    pub fn replayed_bank_hash(&self) -> &Hash {
+        &self.replayed_bank_hash
+    }
+
+    /// The time at which this vote was created
+    pub fn timestamp(&self) -> UnixTimestamp {
+        self.timestamp
+    }
+}
+
+/// A finalization vote
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FinalizationVote {
+    slot: Slot,
+    block_id: Hash,
+    replayed_slot: Slot,
+    replayed_bank_hash: Hash,
+    timestamp: UnixTimestamp,
+}
+
+impl FinalizationVote {
+    fn new_internal(finalization_vote: &FinalizationVoteInstructionData) -> Self {
+        Self {
+            slot: Slot::from(finalization_vote.slot),
+            block_id: finalization_vote.block_id,
+            replayed_slot: Slot::from(finalization_vote.replayed_slot),
+            replayed_bank_hash: finalization_vote.replayed_bank_hash,
+            timestamp: UnixTimestamp::from(finalization_vote.timestamp),
+        }
+    }
+
+    /// Construct a finalization vote for `slot`
+    pub fn new(
+        slot: Slot,
+        block_id: Hash,
+        replayed_slot: Slot,
+        replayed_bank_hash: Hash,
+        timestamp: UnixTimestamp,
+    ) -> Self {
+        Self {
+            slot,
+            block_id,
+            replayed_slot,
+            replayed_bank_hash,
+            timestamp,
+        }
+    }
+
+    /// The slot to notarize
+    pub fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    /// The block_id of the notarization slot
+    pub fn block_id(&self) -> &Hash {
+        &self.block_id
+    }
+
+    /// The latest replayed slot
+    pub fn replayed_slot(&self) -> Slot {
+        self.replayed_slot
+    }
+
+    /// The bank hash of the latest replayed slot
+    pub fn replayed_bank_hash(&self) -> &Hash {
+        &self.replayed_bank_hash
+    }
+
+    /// The time at which this vote was created
+    pub fn timestamp(&self) -> UnixTimestamp {
+        self.timestamp
+    }
+}
+
+/// A skip vote
+/// Represents a range of slots to skip
+/// inclusive on both ends
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SkipVote {
+    start_slot: Slot,
+    end_slot: Slot,
+    timestamp: UnixTimestamp,
+}
+
+impl SkipVote {
+    fn new_internal(skip_vote: &SkipVoteInstructionData) -> Self {
+        Self {
+            start_slot: Slot::from(skip_vote.start_slot),
+            end_slot: Slot::from(skip_vote.end_slot),
+            timestamp: UnixTimestamp::from(skip_vote.timestamp),
+        }
+    }
+
+    /// Construct a skip vote for `[start_slot, end_slot]`
+    pub fn new(start_slot: Slot, end_slot: Slot, timestamp: UnixTimestamp) -> Self {
+        Self {
+            start_slot,
+            end_slot,
+            timestamp,
+        }
+    }
+
+    /// The inclusive on both ends range of slots to skip
+    pub fn skip_range(&self) -> (Slot, Slot) {
+        (self.start_slot, self.end_slot)
+    }
+
+    /// The time at which this vote was created
+    pub fn timestamp(&self) -> UnixTimestamp {
+        self.timestamp
+    }
+}

--- a/program/src/vote_processor.rs
+++ b/program/src/vote_processor.rs
@@ -1,0 +1,105 @@
+use bytemuck::{Pod, Zeroable};
+use solana_program::account_info::AccountInfo;
+use solana_program::hash::Hash;
+use solana_program::program_error::ProgramError;
+use solana_program::pubkey::Pubkey;
+
+use crate::state::{PodSlot, PodUnixTimestamp};
+
+pub(crate) const CURRENT_NOTARIZE_VOTE_VERSION: u8 = 1;
+pub(crate) const CURRENT_FINALIZE_VOTE_VERSION: u8 = 1;
+pub(crate) const CURRENT_SKIP_VOTE_VERSION: u8 = 1;
+
+/// A notarization vote, the data expected by
+/// `VoteInstruction::Notarize`
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub(crate) struct NotarizationVoteInstructionData {
+    /// The version of this vote message
+    pub version: u8,
+
+    /// The slot being notarized
+    pub slot: PodSlot,
+
+    /// The block id of this slot
+    pub block_id: Hash,
+
+    /// The slot of the last replayed block
+    /// Prior to APE this is equal to `slot`
+    pub replayed_slot: PodSlot,
+
+    /// The bank_hash of the last replayed block
+    /// Prior to APE this is the bank hash of `slot`
+    pub replayed_bank_hash: Hash,
+
+    /// The timestamp when this vote was created
+    pub timestamp: PodUnixTimestamp,
+}
+
+/// A finalization vote, the data expected by
+/// `VoteInstruction::Finalize`
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub(crate) struct FinalizationVoteInstructionData {
+    /// The version of this vote message
+    pub version: u8,
+
+    /// The slot being finalized
+    pub slot: PodSlot,
+
+    /// The block id of this slot
+    pub block_id: Hash,
+
+    /// The slot of the last replayed block
+    /// Prior to APE this is equal to `slot`
+    pub replayed_slot: PodSlot,
+
+    /// The bank_hash of the last replayed block
+    /// Prior to APE this is the bank hash of `slot`
+    pub replayed_bank_hash: Hash,
+
+    /// The timestamp when this vote was created
+    pub timestamp: PodUnixTimestamp,
+}
+
+/// A skip vote, the data expected by
+/// `VoteInstruction::Skip`
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub(crate) struct SkipVoteInstructionData {
+    /// The version of this vote message
+    pub version: u8,
+
+    /// The start of the slot range being skipped
+    pub start_slot: PodSlot,
+
+    /// The end (inclusive) of the slot range being skipped
+    pub end_slot: PodSlot,
+
+    /// The timestamp when this vote was created
+    pub timestamp: PodUnixTimestamp,
+}
+
+pub(crate) fn process_notarization_vote(
+    _vote_account: &AccountInfo,
+    _vote_authority: &Pubkey,
+    _vote: &NotarizationVoteInstructionData,
+) -> Result<(), ProgramError> {
+    Ok(())
+}
+
+pub(crate) fn process_finalization_vote(
+    _vote_account: &AccountInfo,
+    _vote_authority: &Pubkey,
+    _vote: &FinalizationVoteInstructionData,
+) -> Result<(), ProgramError> {
+    Ok(())
+}
+
+pub(crate) fn process_skip_vote(
+    _vote_account: &AccountInfo,
+    _vote_authority: &Pubkey,
+    _vote: &SkipVoteInstructionData,
+) -> Result<(), ProgramError> {
+    Ok(())
+}

--- a/program/tests/accounting.rs
+++ b/program/tests/accounting.rs
@@ -116,18 +116,21 @@ async fn test_initialize_vote_account_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&vote_account.data).unwrap();
 
-    assert_eq!(1, vote_state.version);
-    assert_eq!(node_key.pubkey(), vote_state.node_pubkey);
+    assert_eq!(1, vote_state.version());
+    assert_eq!(node_key.pubkey(), *vote_state.node_pubkey());
     assert_eq!(
         authorized_withdrawer.pubkey(),
-        vote_state.authorized_withdrawer
+        *vote_state.authorized_withdrawer()
     );
-    assert_eq!(commission, vote_state.commission);
-    assert_eq!(authorized_voter.pubkey(), vote_state.authorized_voter.voter);
-    assert_eq!(EPOCH, u64::from(vote_state.authorized_voter.epoch));
-    assert_eq!(None, vote_state.next_authorized_voter);
-    assert_eq!(EpochCredit::default(), vote_state.epoch_credits);
-    assert_eq!(BlockTimestamp::default(), vote_state.last_timestamp);
+    assert_eq!(commission, vote_state.commission());
+    assert_eq!(
+        authorized_voter.pubkey(),
+        *vote_state.authorized_voter().voter()
+    );
+    assert_eq!(EPOCH, vote_state.authorized_voter().epoch());
+    assert_eq!(None, vote_state.next_authorized_voter());
+    assert_eq!(EpochCredit::default(), *vote_state.epoch_credits());
+    assert_eq!(BlockTimestamp::default(), *vote_state.latest_timestamp());
 }
 
 #[tokio::test]
@@ -163,7 +166,7 @@ async fn test_authorize_voter_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -194,7 +197,7 @@ async fn test_authorize_voter_basic() {
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
     assert_eq!(
         Some(new_authority.pubkey()),
-        vote_state.next_authorized_voter.map(|nav| nav.voter),
+        vote_state.next_authorized_voter().map(|nav| *nav.voter()),
     );
 }
 
@@ -231,7 +234,7 @@ async fn test_authorize_withdrawer_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -260,7 +263,7 @@ async fn test_authorize_withdrawer_basic() {
         .unwrap();
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
-    assert_eq!(new_authority.pubkey(), vote_state.authorized_withdrawer);
+    assert_eq!(new_authority.pubkey(), *vote_state.authorized_withdrawer());
 }
 
 #[tokio::test]
@@ -296,7 +299,7 @@ async fn test_authorize_checked_voter_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -327,7 +330,7 @@ async fn test_authorize_checked_voter_basic() {
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
     assert_eq!(
         Some(new_authority.pubkey()),
-        vote_state.next_authorized_voter.map(|nav| nav.voter),
+        vote_state.next_authorized_voter().map(|nav| *nav.voter()),
     );
 }
 
@@ -364,7 +367,7 @@ async fn test_authorize_checked_withdrawer_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -393,7 +396,7 @@ async fn test_authorize_checked_withdrawer_basic() {
         .unwrap();
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
-    assert_eq!(new_authority.pubkey(), vote_state.authorized_withdrawer);
+    assert_eq!(new_authority.pubkey(), *vote_state.authorized_withdrawer());
 }
 
 #[tokio::test]
@@ -438,7 +441,7 @@ async fn test_authorize_with_seed_voter_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -471,7 +474,7 @@ async fn test_authorize_with_seed_voter_basic() {
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
     assert_eq!(
         Some(new_authority.pubkey()),
-        vote_state.next_authorized_voter.map(|nav| nav.voter),
+        vote_state.next_authorized_voter().map(|nav| *nav.voter()),
     );
 }
 
@@ -517,7 +520,7 @@ async fn test_authorize_with_seed_withdrawer_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -548,7 +551,7 @@ async fn test_authorize_with_seed_withdrawer_basic() {
         .unwrap();
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
-    assert_eq!(new_authority.pubkey(), vote_state.authorized_withdrawer);
+    assert_eq!(new_authority.pubkey(), *vote_state.authorized_withdrawer());
 }
 
 #[tokio::test]
@@ -593,7 +596,7 @@ async fn test_authorize_checked_with_seed_voter_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -626,7 +629,7 @@ async fn test_authorize_checked_with_seed_voter_basic() {
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
     assert_eq!(
         Some(new_authority.pubkey()),
-        vote_state.next_authorized_voter.map(|nav| nav.voter),
+        vote_state.next_authorized_voter().map(|nav| *nav.voter()),
     );
 }
 
@@ -672,7 +675,7 @@ async fn test_authorize_checked_with_seed_withdrawer_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert!(vote_state.next_authorized_voter.is_none());
+    assert!(vote_state.next_authorized_voter().is_none());
 
     // Issue an Authorize transaction
     let authorize_txn = Transaction::new_signed_with_payer(
@@ -703,7 +706,7 @@ async fn test_authorize_checked_with_seed_withdrawer_basic() {
         .unwrap();
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
-    assert_eq!(new_authority.pubkey(), vote_state.authorized_withdrawer);
+    assert_eq!(new_authority.pubkey(), *vote_state.authorized_withdrawer());
 }
 
 #[tokio::test]
@@ -739,7 +742,7 @@ async fn test_update_commission_basic() {
         .unwrap();
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert_eq!(42, vote_state.commission);
+    assert_eq!(42, vote_state.commission());
 
     // Issue an UpdateCommission transaction
     let update_commission_txn = Transaction::new_signed_with_payer(
@@ -768,7 +771,7 @@ async fn test_update_commission_basic() {
         .unwrap();
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert_eq!(69, vote_state.commission);
+    assert_eq!(69, vote_state.commission());
 }
 
 #[tokio::test]
@@ -806,7 +809,7 @@ async fn test_update_validator_identity_basic() {
 
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert_eq!(node_key.pubkey(), vote_state.node_pubkey);
+    assert_eq!(node_key.pubkey(), *vote_state.node_pubkey());
 
     // Issue an UpdateValidatorIdentity transaction
     let update_vi_txn = Transaction::new_signed_with_payer(
@@ -835,7 +838,7 @@ async fn test_update_validator_identity_basic() {
         .unwrap();
     let vote_state: &VoteState = pod_from_bytes(&account.data).unwrap();
 
-    assert_eq!(new_node_key.pubkey(), vote_state.node_pubkey);
+    assert_eq!(new_node_key.pubkey(), *vote_state.node_pubkey());
 }
 
 #[tokio::test]
@@ -868,8 +871,8 @@ async fn test_withdraw_basic() {
         .unwrap()
         .unwrap();
 
-    // 2_192_400 is the rent exempt amount
-    assert_eq!(2_192_400 + 1_234_567, account.lamports);
+    // 3138960 is the rent exempt amount
+    assert_eq!(3138960 + 1_234_567, account.lamports);
 
     // Issue a Withdraw transaction
     let withdraw_txn = Transaction::new_signed_with_payer(
@@ -898,7 +901,7 @@ async fn test_withdraw_basic() {
         .unwrap()
         .unwrap();
 
-    assert_eq!(2_192_400, vote_account.lamports);
+    assert_eq!(3138960, vote_account.lamports);
 
     // Ensure that the recipient account has the right balance
     let recipient_account = context

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -59,4 +59,6 @@ vote_state
 staker's
 VoteAccount
 node_pubkey
-Withdrawer
+withdrawer/W
+block_id
+bank_hash


### PR DESCRIPTION
Adds data types for voting instructions and updates vote state.

Additionally we add a type in `vote.rs` that clients can use to parse and interact with vote instructions 