### PR TITLE
timestamp fixes: remove from non-notary votes, optional and add slot

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -172,7 +172,7 @@ pub fn notarize(
             block_id: *vote.block_id(),
             _replayed_slot: PodSlot::from(0),
             replayed_bank_hash: *vote.replayed_bank_hash(),
-            timestamp: PodUnixTimestamp::from(vote.timestamp()),
+            timestamp: vote.timestamp().map(PodUnixTimestamp::from),
         },
     )
 }
@@ -197,7 +197,6 @@ pub fn finalize(
             block_id: *vote.block_id(),
             _replayed_slot: PodSlot::from(0),
             replayed_bank_hash: *vote.replayed_bank_hash(),
-            timestamp: PodUnixTimestamp::from(vote.timestamp()),
         },
     )
 }
@@ -217,7 +216,6 @@ pub fn skip(vote_pubkey: Pubkey, vote_authority: Pubkey, vote: SkipVote) -> Inst
             version: CURRENT_SKIP_VOTE_VERSION,
             start_slot: PodSlot::from(start_slot),
             end_slot: PodSlot::from(end_slot),
-            timestamp: PodUnixTimestamp::from(vote.timestamp()),
         },
     )
 }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -44,8 +44,8 @@ pub struct VoteState {
     /// How many credits this validator is earning in this Epoch
     pub(crate) epoch_credits: EpochCredit,
 
-    /// Most recent timestamp submitted with a vote
-    pub(crate) latest_timestamp: PodUnixTimestamp,
+    /// Most recent timestamp submitted with a notarization vote
+    pub(crate) latest_timestamp: BlockTimestamp,
 
     /// The latest notarized slot
     pub(crate) latest_notarized_slot: PodSlot,
@@ -78,6 +78,26 @@ pub struct VoteState {
     /// The bank hash of the latest replayed block
     /// Only relevant after APE
     pub(crate) _replayed_bank_hash: Hash,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, Default, PartialEq)]
+/// The most recent timestamp submitted with a notarization vote
+pub struct BlockTimestamp {
+    pub(crate) slot: PodSlot,
+    pub(crate) timestamp: PodUnixTimestamp,
+}
+
+impl BlockTimestamp {
+    /// The slot that was voted on
+    pub fn slot(&self) -> Slot {
+        Slot::from(self.slot)
+    }
+
+    /// The timestamp
+    pub fn timestamp(&self) -> UnixTimestamp {
+        UnixTimestamp::from(self.timestamp)
+    }
 }
 
 impl VoteState {
@@ -158,8 +178,8 @@ impl VoteState {
     }
 
     /// Most recent timestamp submitted with a vote
-    pub fn latest_timestamp(&self) -> UnixTimestamp {
-        UnixTimestamp::from(self.latest_timestamp)
+    pub fn latest_timestamp(&self) -> &BlockTimestamp {
+        &self.latest_timestamp
     }
 
     /// The latest notarized slot
@@ -233,8 +253,11 @@ impl VoteState {
     }
 
     /// Set the latest timestamp
-    pub fn set_latest_timestamp(&mut self, latest_timestamp: UnixTimestamp) {
-        self.latest_timestamp = PodUnixTimestamp::from(latest_timestamp)
+    pub fn set_latest_timestamp(&mut self, slot: Slot, timestamp: UnixTimestamp) {
+        self.latest_timestamp = BlockTimestamp {
+            slot: PodSlot::from(slot),
+            timestamp: PodUnixTimestamp::from(timestamp),
+        }
     }
 
     /// Set the latest notarized slot

--- a/program/tests/accounting.rs
+++ b/program/tests/accounting.rs
@@ -130,7 +130,11 @@ async fn test_initialize_vote_account_basic() {
     assert_eq!(EPOCH, vote_state.authorized_voter().epoch());
     assert_eq!(None, vote_state.next_authorized_voter());
     assert_eq!(EpochCredit::default(), *vote_state.epoch_credits());
-    assert_eq!(UnixTimestamp::from(0), vote_state.latest_timestamp());
+    assert_eq!(Slot::from(0u64), vote_state.latest_timestamp().slot());
+    assert_eq!(
+        UnixTimestamp::from(0),
+        vote_state.latest_timestamp().timestamp()
+    );
 }
 
 #[tokio::test]
@@ -871,7 +875,7 @@ async fn test_withdraw_basic() {
         .unwrap()
         .unwrap();
 
-    let rent_exempt_amount = 3_528_720;
+    let rent_exempt_amount = 3_584_400;
     assert_eq!(rent_exempt_amount + 1_234_567, account.lamports);
 
     // Issue a Withdraw transaction


### PR DESCRIPTION
This should hopefully clear things up:
- Made the timestamp an option for now by introducing the unsafe trait. This is clearer than trying to use 0 or max int when the validator does not send a timestamp in replay stage. 
- Added the BlockTimestamp with slot back in. When doing the integration I'll see if we can go with the original plan to not have this and derive it in the timestamp oracle.
- Remove the timestamp from finalization and skip votes. Originally had planned to keep this for debugging, but it seems like it's causing too much confusion, we can debug with logs and add it back if necessary. 