### PR TITLE
interface: expose serde and abi example for client types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,13 +147,15 @@ dependencies = [
  "num_enum",
  "rand 0.9.0",
  "serde",
- "serde_bytes",
  "serde_derive",
- "serde_with",
  "serial_test",
  "solana-client",
  "solana-entry",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-hash",
  "solana-ledger",
+ "solana-logger",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -3665,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5238,6 +5240,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-frozen-abi"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685197cf2304e5d26973c72286abb8eb503eede4555b05dbe853d236fd74132c"
+dependencies = [
+ "bs58",
+ "bv",
+ "im",
+ "log",
+ "memmap2",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "sha2 0.10.8",
+ "solana-frozen-abi-macro",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "solana-frozen-abi-macro"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b83f88a126213cbcb57672c5e70ddb9791eff9b480e9f39fe9285fd2abca66fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "solana-genesis-config"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5292,6 +5324,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-atomic-u64",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-sanitize",
  "wasm-bindgen",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,6 +10,14 @@ edition = "2021"
 [features]
 no-entrypoint = []
 test-sbf = []
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "dep:solana-logger",
+    "solana-hash/frozen-abi",
+    "serde",
+]
+serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
 bitflags = { version = "2.9.0", features = ["serde"] }
@@ -21,12 +29,18 @@ num-traits = "0.2"
 either = "1.14.0"
 solana-program = "2.2.0"
 solana-signature = "2.2.0"
-serde = "1.0.218" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
-serde_bytes = "0.11.16"
-serde_derive = "1.0.210" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
-serde_with = { version = "3.12.0", default-features = false }
 thiserror = "2.0"
 spl-pod = "0.5.0"
+solana-hash = "2.2.0"
+solana-frozen-abi = { version = "2.2.0", optional = true, features = [
+    "frozen-abi",
+] }
+solana-frozen-abi-macro = { version = "2.2.0", optional = true, features = [
+    "frozen-abi",
+] }
+solana-logger = { version = "2.2.0", optional = true }
+serde = { version = "1.0.218", optional = true } # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
+serde_derive = { version = "1.0.218", optional = true } # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 
 [dev-dependencies]
 lazy_static = "1.5.0"

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,5 +1,8 @@
 //! Alpenglow Vote program
 #![deny(missing_docs)]
+// Magic to enable frozen abi for on chain programs
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
 pub mod accounting;
 mod entrypoint;
 pub mod error;
@@ -14,3 +17,7 @@ mod vote_processor;
 pub use solana_program;
 
 solana_program::declare_id!("Vote222222222222222222222222222222222222222");
+
+#[cfg_attr(feature = "frozen-abi", macro_use)]
+#[cfg(feature = "frozen-abi")]
+extern crate solana_frozen_abi_macro;

--- a/program/src/vote.rs
+++ b/program/src/vote.rs
@@ -3,9 +3,10 @@
 use std::ops::RangeInclusive;
 
 use either::Either;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use solana_hash::Hash;
 use solana_program::clock::{Slot, UnixTimestamp};
-use solana_program::hash::Hash;
 use solana_program::instruction::Instruction;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
@@ -17,7 +18,13 @@ use crate::vote_processor::{
 
 /// Enum that clients can use to parse and create the vote
 /// structures expected by the program
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor),
+    frozen_abi(digest = "3FyBmZL8rsCkrz6AnqjfgjskNF3HyWMVGejteSP6wC6h")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize,))]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Vote {
     /// A notarization vote
     Notarize(NotarizationVote),
@@ -163,7 +170,13 @@ impl From<SkipVote> for Vote {
 }
 
 /// A notarization vote
-#[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "FjK47hyf3RFm2bVX6My8barMStC2P6cAg3S9ALpvGpwd")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize,))]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct NotarizationVote {
     slot: Slot,
     block_id: Hash,
@@ -222,7 +235,13 @@ impl NotarizationVote {
 }
 
 /// A finalization vote
-#[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "5vg9jirqMy6FbBRm3kZLENrYvaMMZE8brKY99zG2g7FA")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize,))]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct FinalizationVote {
     slot: Slot,
     block_id: Hash,
@@ -269,7 +288,13 @@ impl FinalizationVote {
 /// A skip vote
 /// Represents a range of slots to skip
 /// inclusive on both ends
-#[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample),
+    frozen_abi(digest = "56VUHMkVzrPasPzs1C6Wn4MXUeBqKmApMKiF5Mqyk5xr")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize,))]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct SkipVote {
     pub(crate) start_slot: Slot,
     pub(crate) end_slot: Slot,


### PR DESCRIPTION
We don't use serde on chain, however the client types need to implement serde and AbiExample for use in agave code