### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,4 @@ updates:
     interval: daily
     time: "09:00"
     timezone: UTC
-  open-pull-requests-limit: 6
+  open-pull-requests-limit: 0


### PR DESCRIPTION
It's cumbersome to resolve dependency issues with the integration on alpenglow.

Also dependabot pushes on red 🥴 until we can enforce branch protection rules
![image](https://github.com/user-attachments/assets/e94f83c1-2f41-47a1-95c5-6ddae3aa91c6)

I'll manually update dependencies for now