### PR TITLE
program: disallow overlapping skip votes

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -45,6 +45,10 @@ pub enum VoteError {
     #[error("Skip end slot is lower than the skip start slot")]
     SkipEndSlotLowerThanSkipStartSlot,
 
+    /// New skip range overlaps with previous
+    #[error("Skip range overlaps")]
+    SkipRangeOverlaps,
+
     /// Skip slot range contains finalization vote
     #[error("Skip slot range contains finalization vote")]
     SkipSlotRangeContainsFinalizationVote,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -312,6 +312,14 @@ impl VoteState {
         Slot::from(self.latest_skip_end_slot)
     }
 
+    /// The latest skip range (inclusive)
+    pub fn latest_skip_range(&self) -> (Slot, Slot) {
+        (
+            Slot::from(self.latest_skip_start_slot),
+            Slot::from(self.latest_skip_end_slot),
+        )
+    }
+
     /// Set the node_pubkey
     pub fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
         self.node_pubkey = node_pubkey


### PR DESCRIPTION
When verifying the skip certificate we want to be able to accumulate the skip ranges on `VoteState` after block execution.
This means we have to match the skip pool checks https://github.com/carllin/alpenglow/blob/f08779a9cc965249f1152b09f1ea8e7a9b7a5ae8/core/src/alpenglow_consensus/skip_pool.rs#L163 otherwise a skip range could be overwritten by another transaction, leading to certificate failure.

FYI @ksn6 