### PR TITLE
fix(vote_processor): credits calculation bugfix for notarization and finalization votes

### DIFF
--- a/program/src/vote_processor.rs
+++ b/program/src/vote_processor.rs
@@ -747,13 +747,13 @@ mod tests {
         assert_eq!(0, vote_state.epoch_credits().credits());
         assert_eq!(0, vote_state.epoch_credits().prev_credits());
 
-        let vote_slot = clock.slot - latency;
+        let vote_slot = clock.slot.checked_sub(latency).unwrap();
 
         assert!(process_notarization_finalization_credits(
             &mut vote_state,
             &clock,
             vote_slot,
-            &&epoch_schedule
+            &epoch_schedule
         )
         .is_ok());
 


### PR DESCRIPTION
@wen-coding found that rather than awarding `latency_to_credits(latency)` credits to notarization and finalization votes, we were awarding `latency` credits.

Fixing this issue with tests.