### PR TITLE
Make is_initialized() public, need it in checks.

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -177,7 +177,7 @@ impl VoteState {
         account
     }
 
-    pub(crate) fn is_initialized(&self) -> bool {
+    pub fn is_initialized(&self) -> bool {
         self.version > 0
     }
 


### PR DESCRIPTION
Needs to check whether VoteState is initialized in https://github.com/anza-xyz/alpenglow/pull/87