### PR TITLE
credits: make credits cumulative and based on clock epoch

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -61,10 +61,6 @@ pub enum VoteError {
     #[error("Timestamp is too old")]
     TimestampTooOld,
 
-    /// Unreachable error
-    #[error("Unreachable error")]
-    Unreachable,
-
     /// Version mismatch
     #[error("Version mismatch")]
     VersionMismatch,


### PR DESCRIPTION
Fixup some credits bugs to match previous vote program:
* Credits are cumulative across epochs https://github.com/anza-xyz/solana-sdk/blob/6589b7ef9e9cce9345670ce226532e344f3ece75/vote-interface/src/state/mod.rs#L743
* Credits are awarded by clock's epoch rather than the epoch for which the vote was for https://github.com/anza-xyz/agave/blob/9f217cc9932eea1228ca426bc56067b8942bbeca/programs/vote/src/vote_state/mod.rs#L1006

This also ensures that credits for late votes in previous epochs are rolled into the current epoch