### PR TITLE
Define `BlsPubkey` inside `alpenglow-vote`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ dependencies = [
  "serde_derive",
  "serial_test",
  "solana-account",
- "solana-bls",
  "solana-client",
  "solana-entry",
  "solana-frozen-abi",
@@ -654,18 +653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake3"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,34 +682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blst"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "zeroize",
-]
-
-[[package]]
-name = "blstrs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
-dependencies = [
- "blst",
- "byte-slice-cast",
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "serde",
- "subtle",
 ]
 
 [[package]]
@@ -838,12 +797,6 @@ dependencies = [
  "feature-probe",
  "serde",
 ]
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -1573,17 +1526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,12 +1630,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1904,19 +1840,6 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "spinning_top",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rand_xorshift",
- "subtle",
 ]
 
 [[package]]
@@ -3273,15 +3196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3728,12 +3642,6 @@ checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4826,36 +4734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bls"
-version = "2.3.0"
-source = "git+https://github.com/anza-xyz/alpenglow#0afa729a5c8b4c41752c9e16fd73a8184d0222cc"
-dependencies = [
- "blst",
- "blstrs",
- "bytemuck",
- "ff",
- "group",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "solana-bls12-381",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-bls12-381"
-version = "2.3.0"
-source = "git+https://github.com/anza-xyz/alpenglow#0afa729a5c8b4c41752c9e16fd73a8184d0222cc"
-dependencies = [
- "blst",
- "bytemuck",
- "bytemuck_derive",
- "solana-curve-traits",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "solana-bn254"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5239,11 +5117,6 @@ dependencies = [
  "solana-pubkey",
  "solana-stable-layout",
 ]
-
-[[package]]
-name = "solana-curve-traits"
-version = "2.3.0"
-source = "git+https://github.com/anza-xyz/alpenglow#0afa729a5c8b4c41752c9e16fd73a8184d0222cc"
 
 [[package]]
 name = "solana-curve25519"
@@ -8286,12 +8159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8456,15 +8323,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -9377,15 +9235,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "x509-parser"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -29,7 +29,6 @@ num-traits = "0.2"
 num_enum = "0.7.3"
 serde = { version = "1.0.217", optional = true } # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_derive = { version = "1.0.217", optional = true } # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
-solana-bls = { version = "2.3.0", git = "https://github.com/anza-xyz/alpenglow" }
 solana-frozen-abi = { version = "2.2.1", optional = true, features = [
     "frozen-abi",
 ] }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         error::VoteError,
         id,
-        state::{PodSlot, VoteState},
+        state::{BlsPubkey, PodSlot, VoteState},
         vote::{
             FinalizationVote, NotarizationFallbackVote, NotarizationVote, SkipFallbackVote,
             SkipVote,
@@ -13,7 +13,6 @@ use {
     },
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
-    solana_bls::Pubkey as BlsPubkey,
     solana_program::{
         instruction::{AccountMeta, Instruction},
         program_error::ProgramError,

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,7 +1,6 @@
 //! Program state
 
 use bytemuck::{Pod, Zeroable};
-use solana_bls::Pubkey as BlsPubkey;
 use solana_program::account_info::AccountInfo;
 use solana_program::clock::Clock;
 use solana_program::clock::Epoch;
@@ -281,3 +280,16 @@ impl VoteState {
         self.epoch_credits = epoch_credits
     }
 }
+
+/// A BLS public key (TODO: defining BLS pubkey type inside vote program for now)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BlsPubkey(pub [u8; 96]);
+
+impl Default for BlsPubkey {
+    fn default() -> Self {
+        Self([0; 96])
+    }
+}
+
+unsafe impl Zeroable for BlsPubkey {}
+unsafe impl Pod for BlsPubkey {}

--- a/program/src/vote_processor.rs
+++ b/program/src/vote_processor.rs
@@ -230,7 +230,6 @@ pub(crate) fn process_skip_vote(
 #[cfg(test)]
 mod tests {
     use serial_test::serial;
-    use solana_bls::keypair::Keypair as BlsKeypair;
     use solana_sdk::entrypoint::SUCCESS;
     use solana_sdk::epoch_schedule::EpochSchedule;
     use solana_sdk::hash::Hash;
@@ -246,7 +245,7 @@ mod tests {
     use crate::vote_processor::{award_credits, set_credits};
     use crate::{
         instruction::InitializeAccountInstructionData,
-        state::VoteState,
+        state::{BlsPubkey, VoteState},
         vote_processor::{
             latency_to_credits, VOTE_CREDITS_GRACE_SLOTS, VOTE_CREDITS_MAXIMUM_PER_SLOT,
         },
@@ -291,8 +290,7 @@ mod tests {
     }
 
     fn setup_vote_state(clock: &Clock) -> VoteState {
-        let bls_keypair = BlsKeypair::new();
-        let bls_pubkey = bls_keypair.public.into();
+        let bls_pubkey = BlsPubkey::default();
         let iaid = InitializeAccountInstructionData {
             node_pubkey: Pubkey::new_unique(),
             authorized_voter: Pubkey::new_unique(),

--- a/program/tests/accounting.rs
+++ b/program/tests/accounting.rs
@@ -4,11 +4,11 @@ use {
     alpenglow_vote::{
         accounting::EpochCredit,
         instruction::{self, AuthorityType, InitializeAccountInstructionData},
-        state::VoteState,
+        state::{BlsPubkey, VoteState},
     },
     mollusk_svm::Mollusk,
     rand::Rng,
-    solana_bls::{keypair::Keypair as BlsKeypair, Pubkey as BlsPubkey},
+    rand::RngCore,
     solana_program::pubkey::Pubkey,
     solana_sdk::{
         account::Account,
@@ -18,6 +18,13 @@ use {
     },
     spl_pod::bytemuck::pod_from_bytes,
 };
+
+fn random_bls_pubkey() -> BlsPubkey {
+    let mut rng = rand::rng();
+    let mut array = [0u8; 96];
+    rng.fill_bytes(&mut array);
+    BlsPubkey(array)
+}
 
 const SLOT: Slot = 53_084_024;
 const EPOCH: Epoch = 100;
@@ -88,8 +95,7 @@ fn test_initialize_vote_account_basic() {
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
     let commission: u8 = rand::rng().random();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let instruction = initialize_vote_account_mollusk(
         &vote_account,
@@ -138,8 +144,7 @@ fn test_authorize_voter_basic() {
     let node_key = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let new_authority = Keypair::new();
 
@@ -204,8 +209,7 @@ fn test_authorize_withdrawer_basic() {
     let node_key = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let new_authority = Keypair::new();
 
@@ -267,8 +271,7 @@ fn test_authorize_checked_voter_basic() {
     let node_key = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let new_authority = Keypair::new();
 
@@ -334,8 +337,7 @@ fn test_authorize_checked_withdrawer_basic() {
     let node_key = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let new_authority = Keypair::new();
 
@@ -398,8 +400,7 @@ fn test_authorize_with_seed_voter_basic() {
     let base_key = Keypair::new();
     let voter_seed = "voter-thequickbrownfox";
     let withdrawer_seed = "withdrawer-thequickbrownfox";
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let vote_account = Keypair::new();
     let node_key = Keypair::new();
@@ -477,8 +478,7 @@ fn test_authorize_with_seed_withdrawer_basic() {
     let base_key = Keypair::new();
     let voter_seed = "voter-thequickbrownfox";
     let withdrawer_seed = "withdrawer-thequickbrownfox";
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let vote_account = Keypair::new();
     let node_key = Keypair::new();
@@ -553,8 +553,7 @@ fn test_authorize_checked_with_seed_voter_basic() {
     let base_key = Keypair::new();
     let voter_seed = "voter-thequickbrownfox";
     let withdrawer_seed = "withdrawer-thequickbrownfox";
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let vote_account = Keypair::new();
     let node_key = Keypair::new();
@@ -632,8 +631,7 @@ fn test_authorize_checked_with_seed_withdrawer_basic() {
     let base_key = Keypair::new();
     let voter_seed = "voter-thequickbrownfox";
     let withdrawer_seed = "withdrawer-thequickbrownfox";
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     let vote_account = Keypair::new();
     let node_key = Keypair::new();
@@ -708,8 +706,7 @@ fn test_update_commission_basic() {
     let node_key = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     // Create a vote account with known commission
     let commission_before: u8 = 42;
@@ -772,8 +769,7 @@ fn test_update_validator_identity_basic() {
     let old_node = Keypair::new();
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     // This (probably) won't fail (p is very low - if it fails, you probably win something)
     let new_node = Keypair::new();
@@ -838,8 +834,7 @@ fn test_withdraw_basic() {
     let authorized_voter = Keypair::new();
     let authorized_withdrawer = Keypair::new();
     let recipient_account = Keypair::new();
-    let bls_keypair = BlsKeypair::new();
-    let bls_pubkey = bls_keypair.public.into();
+    let bls_pubkey = random_bls_pubkey();
 
     // Create a vote account
     let initialize_ixn = initialize_vote_account_mollusk(


### PR DESCRIPTION
It seems that the CI can't get access to the `alpenglow` private repo. Defining `BlsPubkey` inside `alpenglow-vote` for now.