### PR TITLE
Organize BLS message into two types and reorder signature

### DIFF
--- a/program/src/bls_message.rs
+++ b/program/src/bls_message.rs
@@ -27,21 +27,21 @@ pub struct BLSMessageVoteData {
 #[derive(Clone, Debug, PartialEq)]
 /// BLS vote message to be sent all to all in Alpenglow
 pub struct BLSVoteMessage {
-    /// The vote data
-    pub vote_data: BLSMessageVoteData,
     /// The signature of the message
     pub signature: BLSSignature,
+    /// The vote data
+    pub vote_data: BLSMessageVoteData,
 }
 
 impl BLSVoteMessage {
     /// Create a new vote message
     pub fn new_vote(vote: Vote, my_rank: u16, signature: BLSSignature) -> Self {
         Self {
+            signature,
             vote_data: BLSMessageVoteData {
                 vote,
                 rank: my_rank,
             },
-            signature,
         }
     }
 
@@ -62,10 +62,10 @@ impl BLSVoteMessage {
 #[derive(Clone, Debug, PartialEq)]
 /// BLS certificate message to be sent all to all in Alpenglow
 pub struct BLSCertificateMessage {
-    /// The certificate
-    pub certificate: Certificate,
     /// The signature of the message
     pub signature: BLSSignature,
+    /// The certificate
+    pub certificate: Certificate,
 }
 
 impl BLSCertificateMessage {
@@ -76,9 +76,10 @@ impl BLSCertificateMessage {
         block_id: Option<Hash>,
         replayed_bank_hash: Option<Hash>,
         bitmap: BitVec<u8, Lsb0>,
-        signature: BLSSignature,
+        aggregate_signature: BLSSignature,
     ) -> Self {
         Self {
+            signature,
             certificate: Certificate {
                 certificate_type,
                 slot,
@@ -86,7 +87,6 @@ impl BLSCertificateMessage {
                 replayed_bank_hash,
                 bitmap,
             },
-            signature,
         }
     }
 


### PR DESCRIPTION
Currently, the type `BLSMessage` can be either a vote message or a certificate message. However, the processing logic for these two types of messages are verify different and we generally need to write functions for one type or the other. It is much more convenient if these two types of BLS messages is formally split into two types `BLSVoteMessage` and `BLSCertificateMessage`.

I split the `BLSMessage` into the two types. I also moved the signature field so that it precedes the vote and certificate data. Since the certificate data contains the bit vector, it would be much easier to truncate the bit vector if it comes last in the message format.