### PR TITLE
Organize BLS message into two types and reorder signature

### DIFF
--- a/program/src/bls_message.rs
+++ b/program/src/bls_message.rs
@@ -3,14 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 use {
-    crate::{
-        certificate::{CertificateMessage, CertificateType},
-        vote::Vote,
-    },
+    crate::{certificate::Certificate, vote::Vote},
     bitvec::prelude::*,
     solana_bls::Signature as BLSSignature,
-    solana_hash::Hash,
-    solana_program::clock::Slot,
 };
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -23,6 +18,18 @@ pub struct VoteMessage {
     pub signature: BLSSignature,
     /// The rank of the validator
     pub rank: u16,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq)]
+/// BLS vote message, we need rank to look up pubkey
+pub struct CertificateMessage {
+    /// The certificate
+    pub certificate: Certificate,
+    /// The signature
+    pub signature: BLSSignature,
+    /// The bitmap for validators, little endian byte order
+    pub bitmap: BitVec<u8, Lsb0>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -48,18 +55,12 @@ impl BLSMessage {
 
     /// Create a new certificate message
     pub fn new_certificate(
-        certificate_type: CertificateType,
-        slot: Slot,
-        block_id: Option<Hash>,
-        replayed_bank_hash: Option<Hash>,
+        certificate: Certificate,
         bitmap: BitVec<u8, Lsb0>,
         signature: BLSSignature,
     ) -> Self {
         Self::Certificate(CertificateMessage {
-            certificate_type,
-            slot,
-            block_id,
-            replayed_bank_hash,
+            certificate,
             signature,
             bitmap,
         })

--- a/program/src/certificate.rs
+++ b/program/src/certificate.rs
@@ -2,10 +2,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use {
-    bitvec::prelude::*, solana_bls::Signature as BLSSignature, solana_hash::Hash,
-    solana_program::clock::Slot,
-};
+use {solana_hash::Hash, solana_program::clock::Slot};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -26,7 +23,7 @@ pub enum CertificateType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 /// Certificate Type in Alpenglow
-pub struct CertificateMessage {
+pub struct Certificate {
     /// Certificate type
     pub certificate_type: CertificateType,
     /// The slot of the block
@@ -35,8 +32,4 @@ pub struct CertificateMessage {
     pub block_id: Option<Hash>,
     /// The bank hash of the block
     pub replayed_bank_hash: Option<Hash>,
-    /// The BLS signature
-    pub signature: BLSSignature,
-    /// The bitmap for validators, little endian byte order
-    pub bitmap: BitVec<u8, Lsb0>,
 }


### PR DESCRIPTION
Currently, the type BLSMessage can be either a vote message or a certificate message. However, the processing logic for these two types of messages are verify different and we generally need to write functions for one type or the other. It is much more convenient if these two types of BLS messages is formally split into two types BLSVoteMessage and BLSCertificateMessage.

I split the BLSMessage into the two types. I also moved the signature field so that it precedes the vote and certificate data. Since the certificate data contains the bit vector, it would be much easier to truncate the bit vector if it comes last in the message format.